### PR TITLE
 plot.New()  now only returns one variable not two

### DIFF
--- a/bezier.go
+++ b/bezier.go
@@ -51,15 +51,12 @@ func Points() plotter.XYs {
 }
 func main(){
 
-	p, err := plot.New()
-	if err != nil {
-		panic(err)
-	}
+	p := plot.New()
 
 	p.X.Label.Text = "X"
 	p.Y.Label.Text = "Y"
 
-	err = plotutil.AddLinePoints(p,
+	err := plotutil.AddLinePoints(p,
 		"Bézier Curve", Points())
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
updated call to  plot.New()
since it now only returns one variable not two

```
go version
go version go1.19.2 linux/amd64

```

to execute issue

```
go mod init 
go mod tidy
go build
./Bezier-curve-in-Go

```

